### PR TITLE
Registraion match charity website domain with user email domain to make it active

### DIFF
--- a/backend/open_webui/migrations/versions/3cb05395b8f3_add_is_email_verified_userprofile.py
+++ b/backend/open_webui/migrations/versions/3cb05395b8f3_add_is_email_verified_userprofile.py
@@ -1,0 +1,27 @@
+"""Add is_email_verified UserProfile
+
+Revision ID: 3cb05395b8f3
+Revises: 5b475881d81b
+Create Date: 2025-07-23 10:41:49.663121
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import open_webui.internal.db
+from sqlalchemy.dialects import sqlite
+
+# revision identifiers, used by Alembic.
+revision: str = '3cb05395b8f3'
+down_revision: Union[str, None] = '5b475881d81b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('user_profile', sa.Column('is_email_verified', sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('user_profile', 'is_email_verified')

--- a/backend/open_webui/migrations/versions/3cb05395b8f3_add_is_email_verified_userprofile.py
+++ b/backend/open_webui/migrations/versions/3cb05395b8f3_add_is_email_verified_userprofile.py
@@ -20,7 +20,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column('user_profile', sa.Column('is_email_verified', sa.Boolean(), nullable=True))
+    op.add_column('user_profile', sa.Column('is_email_verified', sa.Boolean(), nullable=True, server_default=sa.false()))
 
 
 def downgrade() -> None:

--- a/backend/open_webui/models/charities.py
+++ b/backend/open_webui/models/charities.py
@@ -37,10 +37,14 @@ class CharityModel(BaseModel):
         website = getattr(self, "website", None)
         if not website:
             return None
+        if "://" not in website:
+            website = "http://" + website
         parsed = urlparse(website)
         domain = parsed.hostname
+
         if not domain:
             return None
+
         domain = domain.lower()
         if domain.startswith("www."):
             domain = domain[4:]

--- a/backend/open_webui/models/charities.py
+++ b/backend/open_webui/models/charities.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Optional
+from urllib.parse import urlparse
 
 from open_webui.env import SRC_LOG_LEVELS
 from open_webui.internal.db import Base, get_db
@@ -31,6 +32,19 @@ class CharityModel(BaseModel):
     is_imported: bool = False
 
     model_config = ConfigDict(from_attributes=True)
+
+    def get_website_domain(self):
+        website = getattr(self, "website", None)
+        if not website:
+            return None
+        parsed = urlparse(website)
+        domain = parsed.hostname
+        if not domain:
+            return None
+        domain = domain.lower()
+        if domain.startswith("www."):
+            domain = domain[4:]
+        return domain
 
 
 class CharityResponse(BaseModel):

--- a/backend/open_webui/models/profiles.py
+++ b/backend/open_webui/models/profiles.py
@@ -1,10 +1,14 @@
+import logging
 from typing import Optional
 
 from open_webui.internal.db import Base, get_db
 from open_webui.models.charities import CharityModel
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import Boolean, Column, ForeignKey, Integer
-from sqlalchemy.orm import relationship
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, relationship
+
+logger = logging.getLogger(__name__)
 
 
 class UserProfile(Base):
@@ -45,33 +49,50 @@ class UserProfileModel(BaseModel):
 
 
 class UserProfileTable:
+
+    def assign_charity(
+        self, db: Session, user_id: str, charity_id: Optional[int]
+    ) -> Optional[UserProfile]:
+        """
+        Assign or clear a user's charity within an existing DB session.
+        Does not commit — caller is responsible for commit/rollback.
+        Returns ORM profile or None if user not found.
+        """
+        from open_webui.models.users import User
+
+        user = db.query(User).filter_by(id=user_id).first()
+        if not user:
+            return None
+
+        profile = db.query(UserProfile).filter_by(user_id=user_id).first()
+        if not profile:
+            profile = UserProfile(user_id=user_id)
+            db.add(profile)
+
+        profile.charity_id = charity_id
+        db.flush()
+        return profile
+
     def set_user_charity(
         self, user_id: str, charity_id: Optional[int]
     ) -> Optional[UserProfileModel]:
         """
         Set the user's charity. Creates a UserProfile for the user if it does not exist.
         """
-        from open_webui.models.users import User
 
+        db = None
         try:
             with get_db() as db:
-                # Check if user exists
-                user = db.query(User).filter_by(id=user_id).first()
-                if not user:
-                    return False
+                profile = self.assign_charity(db, user_id, charity_id)
+                if profile is None:
+                    return None
 
-                # Get or create the UserProfile
-                user_profile = db.query(UserProfile).filter_by(user_id=user_id).first()
-                if not user_profile:
-                    user_profile = UserProfile(user_id=user_id)
-                    db.add(user_profile)
-
-                user_profile.charity_id = charity_id
                 db.commit()
-                db.refresh(user_profile)
-                return UserProfileModel.model_validate(user_profile)
-        except Exception as e:
-            print("Error in set_user_charity:", e)
+                db.refresh(profile)
+                return UserProfileModel.model_validate(profile)
+        except SQLAlchemyError:
+            if db is not None:
+                db.rollback()
             return None
 
 

--- a/backend/open_webui/models/profiles.py
+++ b/backend/open_webui/models/profiles.py
@@ -3,11 +3,12 @@ from typing import Optional
 from open_webui.internal.db import Base, get_db
 from open_webui.models.charities import CharityModel
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import Column, ForeignKey, Integer
+from sqlalchemy import Boolean, Column, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
 
 class UserProfile(Base):
+
     __tablename__ = "user_profile"
     id = Column(Integer, primary_key=True)
 
@@ -16,6 +17,8 @@ class UserProfile(Base):
 
     user_id = Column(Integer, ForeignKey("user.id"))
     user = relationship("User", back_populates="profile")
+
+    is_email_verified = Column(Boolean, default=False)
 
 
 class UserProfileForm(BaseModel):
@@ -28,9 +31,23 @@ class UserProfileModel(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+    def get_email_domain(self, user):
+        if not user.email:
+            return None
+
+        email = user.email.strip().lower()
+
+        try:
+            domain = email.split("@")[1]
+        except IndexError:
+            return None
+        return domain
+
 
 class UserProfileTable:
-    def set_user_charity(self, user_id: str, charity_id: Optional[int]) -> bool:
+    def set_user_charity(
+        self, user_id: str, charity_id: Optional[int]
+    ) -> Optional[UserProfileModel]:
         """
         Set the user's charity. Creates a UserProfile for the user if it does not exist.
         """
@@ -51,10 +68,11 @@ class UserProfileTable:
 
                 user_profile.charity_id = charity_id
                 db.commit()
-                return True
+                db.refresh(user_profile)
+                return UserProfileModel.model_validate(user_profile)
         except Exception as e:
             print("Error in set_user_charity:", e)
-            return False
+            return None
 
 
 UserProfiles = UserProfileTable()

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -658,8 +658,14 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
                 request.app.state.config.ENABLE_SIGNUP = False
 
             # Create user profile and set the charity
-            UserProfiles.set_user_charity(user.id, getattr(charity, "id", None))
+            user_profile = UserProfiles.set_user_charity(user.id, getattr(charity, "id", None))
 
+            if charity and user_profile:
+                charity_domain = charity.get_website_domain()
+                user_email_domain = user_profile.get_email_domain(user=user)
+                if charity_domain is not None and user_email_domain is not None:
+                    if charity_domain == user_email_domain:
+                        user = Users.update_user_role_by_id(user.id, 'user')
 
             return {
                 "token": token,


### PR DESCRIPTION
### Source
https://trello.com/c/bVJ3EPZz/14-ai-sprint-6-implement-email-verification-and-domain-matching-logic

### Description
- Extract the domain from the user’s email address (e.g., user@domain.com → domain.com).
- Compare the extracted domain with the domain of the selected charity’s website.
- If the domains match, automatically approve the users (change role to `user` instead of pending)

### Setup instructions
To set up the project, please refer to `DEV_README.md` for detailed steps.

Once you have completed the setup, switch to this branch to continue.

Make sure you have the charities imported as per https://github.com/developersociety/castopenwebui/pull/1

Make sure signups are enabled as per https://github.com/developersociety/castopenwebui/pull/2

### How to test
1. Go to http://localhost:5173/auth and click **Sign up** enter email as test@ifcharity.org.uk and select charity as "if...." and it should let you into the system after clicking **Create Account**