### PR TITLE
Add email verification

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -86,6 +86,7 @@ from open_webui.routers import (
     users,
     utils,
     charities,
+    profiles,
 )
 
 from open_webui.routers.retrieval import (
@@ -1212,6 +1213,7 @@ app.include_router(
 )
 app.include_router(utils.router, prefix="/api/v1/utils", tags=["utils"])
 app.include_router(charities.router, prefix="/api/v1/charities", tags=["charities"])
+app.include_router(profiles.router, prefix="/api/v1/profiles", tags=["profiles"])
 
 
 try:

--- a/backend/open_webui/models/profiles.py
+++ b/backend/open_webui/models/profiles.py
@@ -1,10 +1,15 @@
+import logging
 from typing import Optional
 
+from open_webui.env import SRC_LOG_LEVELS
 from open_webui.internal.db import Base, get_db
 from open_webui.models.charities import CharityModel
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import Boolean, Column, ForeignKey, Integer
 from sqlalchemy.orm import relationship
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["MODELS"])
 
 
 class UserProfile(Base):
@@ -18,16 +23,19 @@ class UserProfile(Base):
     user_id = Column(Integer, ForeignKey("user.id"))
     user = relationship("User", back_populates="profile")
 
-    is_email_verified = Column(Boolean, default=False)
+    is_email_verified = Column(Boolean, default=False, nullable=False)
 
 
 class UserProfileForm(BaseModel):
     user_id: str
     charity_id: Optional[int] = None
+    is_email_verified: Optional[bool]
 
 
 class UserProfileModel(BaseModel):
     charity: Optional[CharityModel] = None
+    id: int
+    is_email_verified: Optional[bool] = False
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -45,8 +53,8 @@ class UserProfileModel(BaseModel):
 
 
 class UserProfileTable:
-    def set_user_charity(
-        self, user_id: str, charity_id: Optional[int]
+    def update_or_create_user_profile(
+        self, user_id: str, charity_id: Optional[int], is_email_verified: Optional[bool]
     ) -> Optional[UserProfileModel]:
         """
         Set the user's charity. Creates a UserProfile for the user if it does not exist.
@@ -67,11 +75,60 @@ class UserProfileTable:
                     db.add(user_profile)
 
                 user_profile.charity_id = charity_id
+
+                # Change is_email_verified
+                if is_email_verified:
+                    user_profile.is_email_verified = is_email_verified
+
                 db.commit()
                 db.refresh(user_profile)
                 return UserProfileModel.model_validate(user_profile)
         except Exception as e:
-            print("Error in set_user_charity:", e)
+            print("Error in update_or_create_user_profile:", e)
+            return None
+
+    def get_userprofile_by_email(self, email: str) -> Optional[UserProfileModel]:
+        from open_webui.models.users import User  # prevent circular imports
+
+        try:
+            with get_db() as db:
+                user_profile = (
+                    db.query(UserProfile).join(User).filter(User.email == email).first()
+                )
+                return (
+                    UserProfileModel.model_validate(user_profile)
+                    if user_profile
+                    else None
+                )
+        except Exception:
+            return None
+
+    def update_is_email_verified(
+        self, id: int, is_email_verified: bool
+    ) -> Optional[UserProfileModel]:
+        try:
+            with get_db() as db:
+                db.query(UserProfile).filter_by(id=id).update(
+                    {
+                        "is_email_verified": is_email_verified,
+                    }
+                )
+                db.commit()
+                return self.get_user_profile_by_id(id=id)
+        except Exception as e:
+            log.exception(e)
+            return None
+
+    def get_user_profile_by_id(self, id: str) -> Optional[UserProfileModel]:
+        try:
+            with get_db() as db:
+                user_profile = db.query(UserProfile).filter_by(id=id).first()
+                return (
+                    UserProfileModel.model_validate(user_profile)
+                    if user_profile
+                    else None
+                )
+        except Exception:
             return None
 
 

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 from aiohttp import ClientSession
 
+from open_webui.utils.profiles import process_signin, process_signup
 from open_webui.models.charities import Charities
 from open_webui.models.profiles import UserProfiles
 from open_webui.models.auths import (
@@ -73,6 +74,7 @@ log.setLevel(SRC_LOG_LEVELS["MAIN"])
 class SessionUserResponse(Token, UserResponse):
     expires_at: Optional[int] = None
     permissions: Optional[dict] = None
+    is_email_verified: Optional[bool] = None
 
 
 @router.get("/", response_model=SessionUserResponse)
@@ -114,6 +116,8 @@ async def get_session_user(
         user.id, request.app.state.config.USER_PERMISSIONS
     )
 
+    user_profile = UserProfiles.get_userprofile_by_email(user.email)
+
     return {
         "token": token,
         "token_type": "Bearer",
@@ -124,6 +128,7 @@ async def get_session_user(
         "role": user.role,
         "profile_image_url": user.profile_image_url,
         "permissions": user_permissions,
+        "is_email_verified": getattr(user_profile, "is_email_verified", False),
     }
 
 
@@ -536,6 +541,9 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
             user.id, request.app.state.config.USER_PERMISSIONS
         )
 
+        # DEV process signin
+        user_profile = process_signin(user)
+
         return {
             "token": token,
             "token_type": "Bearer",
@@ -546,6 +554,7 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
             "role": user.role,
             "profile_image_url": user.profile_image_url,
             "permissions": user_permissions,
+            "is_email_verified": getattr(user_profile, "is_email_verified"),
         }
     else:
         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
@@ -657,15 +666,8 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
                 # Disable signup after the first user is created
                 request.app.state.config.ENABLE_SIGNUP = False
 
-            # Create user profile and set the charity
-            user_profile = UserProfiles.set_user_charity(user.id, getattr(charity, "id", None))
-
-            if charity and user_profile:
-                charity_domain = charity.get_website_domain()
-                user_email_domain = user_profile.get_email_domain(user=user)
-                if charity_domain is not None and user_email_domain is not None:
-                    if charity_domain == user_email_domain:
-                        user = Users.update_user_role_by_id(user.id, 'user')
+            # DEV process signup
+            user, user_profile = process_signup(request=request, user=user, charity=charity)
 
             return {
                 "token": token,
@@ -677,6 +679,7 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
                 "role": user.role,
                 "profile_image_url": user.profile_image_url,
                 "permissions": user_permissions,
+                "is_email_verified": getattr(user_profile, "is_email_verified", False),
             }
         else:
             raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)
@@ -769,7 +772,7 @@ async def add_user(form_data: AddUserForm, user=Depends(get_admin_user)):
 
         if user:
             charity_id = getattr(form_data, "charity_id", None)
-            UserProfiles.set_user_charity(user.id, charity_id)
+            UserProfiles.update_or_create_user_profile(user.id, charity_id, None)
 
             token = create_token(data={"id": user.id})
             return {

--- a/backend/open_webui/routers/profiles.py
+++ b/backend/open_webui/routers/profiles.py
@@ -1,0 +1,36 @@
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from itsdangerous import BadSignature, SignatureExpired
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.models.profiles import UserProfileModel, UserProfiles
+from open_webui.utils.profiles import get_email_verification_serializer
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["MODELS"])
+
+router = APIRouter()
+
+
+@router.get(
+    "/verify-email", name="verify-email", response_model=Optional[UserProfileModel]
+)
+async def verify_email(token: str):
+    serializer = get_email_verification_serializer()
+    try:
+        # 1 week expiry
+        email = serializer.loads(
+            token, salt="email-confirmation-salt", max_age=60 * 60 * 24 * 7
+        )
+    except SignatureExpired:
+        raise HTTPException(status_code=400, detail="Verification link expired.")
+    except BadSignature:
+        raise HTTPException(status_code=400, detail="Invalid verification token.")
+    user_profile = UserProfiles.get_userprofile_by_email(email)
+    if not user_profile:
+        raise HTTPException(status_code=404, detail="User not found")
+    user_profile = UserProfiles.update_is_email_verified(
+        id=int(user_profile.id), is_email_verified=True
+    )
+    return user_profile

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -408,8 +408,9 @@ async def update_user_by_id(
             profile = getattr(form_data, "profile", None)
             charity = getattr(profile, "charity", None)
             charity_id = getattr(charity, "id", None)
+            is_email_verified = getattr(profile, "is_email_verified", None)
 
-            UserProfiles.set_user_charity(user_id, charity_id)
+            UserProfiles.update_or_create_user_profile(user_id, charity_id, is_email_verified)
 
             return updated_user
 

--- a/backend/open_webui/utils/profiles.py
+++ b/backend/open_webui/utils/profiles.py
@@ -1,0 +1,167 @@
+import logging
+import os
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Any
+
+import boto3
+from fastapi import Request
+from itsdangerous import URLSafeTimedSerializer
+from open_webui.env import WEBUI_NAME, WEBUI_SECRET_KEY
+from open_webui.models.profiles import UserProfiles
+from open_webui.models.users import Users
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "cast@devemail.org")
+TO_EMAIL_ON_NEW_USER_SIGNUPS = os.environ.get(
+    "TO_EMAIL_ON_NEW_USER_SIGNUPS", "steve@dev.ngo"
+)
+FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL", None)
+LOCAL = os.environ.get("LOCAL", False)
+
+
+def get_email_verification_serializer() -> URLSafeTimedSerializer:
+    """
+    Returns a URLSafeTimedSerializer instance for generating and validating
+    email verification tokens.
+    """
+    return URLSafeTimedSerializer(WEBUI_SECRET_KEY)
+
+
+def send_verification_email(request: Request, email: str):
+    serializer = get_email_verification_serializer()
+    token = serializer.dumps(email, salt="email-confirmation-salt")
+
+    if FRONTEND_BASE_URL:
+        url = f"{FRONTEND_BASE_URL}verify?token={token}"
+    else:
+        url = f"{request.base_url}verify?token={token}"
+
+    msg = MIMEMultipart()
+    msg["Subject"] = "Verify your email"
+    msg["From"] = DEFAULT_FROM_EMAIL
+    msg["To"] = email
+    body = MIMEText(f"Click the link {url} to verify your email!", "plain")
+    msg.attach(body)
+
+    if LOCAL:
+        send_email(e_to=[email], config={}, mime_msg=msg, dryrun=True)
+    else:
+        send_email(e_to=[email], config={}, mime_msg=msg, dryrun=False)
+
+
+def send_admin_email_notification(user):
+    user_profile = user.profile
+    msg = MIMEMultipart()
+    msg["Subject"] = f"New user signup on {WEBUI_NAME}"
+    msg["From"] = DEFAULT_FROM_EMAIL
+    msg["To"] = TO_EMAIL_ON_NEW_USER_SIGNUPS
+    if user.role == "user":
+        status_text = f"A new user has registered on {WEBUI_NAME} and their account is already active."
+    else:
+        status_text = f"There is a new user registered on {WEBUI_NAME} that needs to be authorised."
+
+    body = (
+        f"{status_text}\n\n"
+        f"Email: {user.email}\n"
+        f"Name: {getattr(user, 'name', '')}\n"
+        f"Charity: {getattr(getattr(user_profile, 'charity', None), 'name', '')}\n"
+    )
+    msg.attach(MIMEText(body))
+    if LOCAL:
+        send_email(
+            e_to=[TO_EMAIL_ON_NEW_USER_SIGNUPS], config={}, mime_msg=msg, dryrun=True
+        )
+    else:
+        send_email(
+            e_to=[TO_EMAIL_ON_NEW_USER_SIGNUPS], config={}, mime_msg=msg, dryrun=True
+        )
+
+
+def send_email(
+    e_to: list[str],
+    mime_msg: MIMEMultipart,
+    config: dict[str, Any],
+    dryrun: bool = False,
+) -> None:
+    if dryrun:
+        logger.info("Dryrun enabled, email notification content is below:")
+        logger.info(mime_msg.as_string())
+        return
+
+    client = boto3.client(
+        "sesv2", region_name=os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    )
+
+    send_email_kwargs = {}
+    if os.environ.get("AWS_SES_FROM_ARN"):
+        send_email_kwargs["FromEmailAddressIdentityArn"] = os.environ[
+            "AWS_SES_FROM_ARN"
+        ]
+    if os.environ.get("AWS_SES_FEEDBACK_EMAIL"):
+        send_email_kwargs["FeedbackForwardingEmailAddress"] = os.environ[
+            "AWS_SES_FEEDBACK_EMAIL"
+        ]
+    if os.environ.get("AWS_SES_FEEDBACK_ARN"):
+        send_email_kwargs["FeedbackForwardingEmailAddressIdentityArn"] = os.environ[
+            "AWS_SES_FEEDBACK_ARN"
+        ]
+
+    client.send_email(
+        FromEmailAddress=DEFAULT_FROM_EMAIL,
+        Destination={
+            "ToAddresses": e_to,
+        },
+        Content={
+            "Raw": {
+                "Data": mime_msg.as_bytes(),
+            },
+        },
+        ConfigurationSetName=os.environ["AWS_SES_CONFIGURATION_SET_NAME"],
+        **send_email_kwargs,
+    )
+
+
+def process_signup(request, user, charity):
+    """
+    Handles the signup processing workflow for a new user.
+
+    This function performs the following steps:
+        1. Creates or updates the user's profile and associates it with the specified charity.
+        2. Refreshes and retrieves the updated user from the database (including the new profile).
+        3. Sends a verification email to the user.
+        4. Sends an admin notification email about the new signup.
+        5. If both a charity and user profile exist, and the user's email domain matches the charity's website domain,
+           updates the user's role to 'user'.
+    """
+    # Create user profile and set the charity
+    user_profile = UserProfiles.update_or_create_user_profile(
+        user.id, getattr(charity, "id", None), None
+    )
+    # Refresh user after creating profile
+    user = Users.get_user_by_id(user.id)
+    send_verification_email(request, user.email)
+    send_admin_email_notification(user)
+
+    if charity and user_profile:
+        charity_domain = charity.get_website_domain()
+        user_email_domain = user_profile.get_email_domain(user=user)
+        if charity_domain is not None and user_email_domain is not None:
+            if charity_domain == user_email_domain:
+                user = Users.update_user_role_by_id(user.id, "user")
+
+    return user, user_profile
+
+
+def process_signin(user):
+    """
+    Handles user sign-in processing, including email verification if necessary.
+    """
+    user_profile = UserProfiles.get_userprofile_by_email(user.email)
+    if not getattr(user_profile, "is_email_verified", False):
+        # Resend verification email if user still not verified their email
+        send_verification_email(user.email)
+    return user_profile

--- a/backend/open_webui/utils/profiles.py
+++ b/backend/open_webui/utils/profiles.py
@@ -3,6 +3,7 @@ import os
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any
+from urllib.parse import quote
 
 import boto3
 from fastapi import Request
@@ -36,9 +37,9 @@ def send_verification_email(request: Request, email: str):
     token = serializer.dumps(email, salt="email-confirmation-salt")
 
     if FRONTEND_BASE_URL:
-        url = f"{FRONTEND_BASE_URL}verify?token={token}"
+        url = f"{FRONTEND_BASE_URL}verify?token={quote(token)}"
     else:
-        url = f"{request.base_url}verify?token={token}"
+        url = f"{request.base_url}verify?token={quote(token)}"
 
     msg = MIMEMultipart()
     msg["Subject"] = "Verify your email"

--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -306,6 +306,15 @@
 						</div>
 					</th>
 
+					<th scope="col" class="px-3 py-1.5 cursor-pointer select-none">
+						<div class="flex gap-1.5 items-center">
+							{$i18n.t('Is email verified?')}
+							<span class="invisible">
+								<ChevronUp className="size-2" />
+							</span>
+						</div>
+					</th>
+
 					<th
 						scope="col"
 						class="px-3 py-1.5 cursor-pointer select-none"
@@ -413,6 +422,7 @@
 						</td>
 						<td class=" px-3 py-1"> {user.email} </td>
 						<td class=" px-3 py-1"> {user?.profile?.charity?.name ?? ''} </td>
+						<td class=" px-3 py-1"> {user?.profile?.is_email_verified} </td>
 
 						<td class=" px-3 py-1">
 							{dayjs(user.last_active_at * 1000).fromNow()}

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -25,17 +25,10 @@
 		name: '',
 		email: '',
 		password: '',
-		profile: null
+		profile: {}
 	};
 
-	let selectedCharity = null;
-
 	const submitHandler = async () => {
-		// User profile must exist before the assignment of selectedCharity
-		if (!_user.profile) _user.profile = {};
-
-		_user.profile.charity = selectedCharity;
-
 		const res = await updateUserById(localStorage.token, selectedUser.id, _user).catch((error) => {
 			toast.error(`${error}`);
 		});
@@ -50,7 +43,6 @@
 		if (selectedUser) {
 			_user = selectedUser;
 			_user.password = '';
-			selectedCharity = _user.profile?.charity || null;
 		}
 	});
 </script>
@@ -119,7 +111,7 @@
 								<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Charity')}</div>
 
 								<div class="flex-1">
-									<CharityAutocomplete bind:value={selectedCharity} />
+									<CharityAutocomplete bind:value={_user.profile.charity} />
 								</div>
 							</div>
 
@@ -135,6 +127,16 @@
 										autocomplete="off"
 										required
 									/>
+								</div>
+							</div>
+
+							<div class="flex flex-col w-full">
+								<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Is email verified?')}</div>
+
+								<div class="flex-1">
+									{#if _user.profile}
+										<input type="checkbox" bind:checked={_user.profile.is_email_verified} />
+									{/if}
 								</div>
 							</div>
 

--- a/src/lib/components/layout/Overlay/AccountPending.svelte
+++ b/src/lib/components/layout/Overlay/AccountPending.svelte
@@ -2,6 +2,7 @@
 	import { getAdminDetails } from '$lib/apis/auths';
 	import { onMount, tick, getContext } from 'svelte';
 	import { config } from '$lib/stores';
+	import { user } from '$lib/stores';
 
 	const i18n = getContext('i18n');
 
@@ -21,30 +22,42 @@
 	>
 		<div class="m-auto pb-10 flex flex-col justify-center">
 			<div class="max-w-md">
-				<div
-					class="text-center dark:text-white text-2xl font-medium z-50"
-					style="white-space: pre-wrap;"
-				>
-					{#if ($config?.ui?.pending_user_overlay_title ?? '').trim() !== ''}
-						{$config.ui.pending_user_overlay_title}
-					{:else}
-						{$i18n.t('Account Activation Pending')}<br />
-						{$i18n.t('Contact Admin for WebUI Access')}
-					{/if}
-				</div>
+				{#if $user && $user.is_email_verified === false && $user.role === 'pending'}
+					<div class="bg-yellow-200 text-yellow-900 px-4 py-2 rounded mb-4 text-center font-medium">
+						Please verify your email address to unlock full access and wait for approval.
+					</div>
+				{:else if $user && $user.is_email_verified === false}
+					<div class="bg-yellow-200 text-yellow-900 px-4 py-2 rounded mb-4 text-center font-medium">
+						Please verify your email address to unlock full access.
+					</div>
+				{/if}
 
-				<div
-					class=" mt-4 text-center text-sm dark:text-gray-200 w-full"
-					style="white-space: pre-wrap;"
-				>
-					{#if ($config?.ui?.pending_user_overlay_content ?? '').trim() !== ''}
-						{$config.ui.pending_user_overlay_content}
-					{:else}
-						{$i18n.t('Your account status is currently pending activation.')}{'\n'}{$i18n.t(
-							'To access the WebUI, please reach out to the administrator. Admins can manage user statuses from the Admin Panel.'
-						)}
-					{/if}
-				</div>
+				{#if $user.role === 'pending'}
+					<div
+						class="text-center dark:text-white text-2xl font-medium z-50"
+						style="white-space: pre-wrap;"
+					>
+						{#if ($config?.ui?.pending_user_overlay_title ?? '').trim() !== ''}
+							{$config.ui.pending_user_overlay_title}
+						{:else}
+							{$i18n.t('Account Activation Pending')}<br />
+							{$i18n.t('Contact Admin for WebUI Access')}
+						{/if}
+					</div>
+
+					<div
+						class=" mt-4 text-center text-sm dark:text-gray-200 w-full"
+						style="white-space: pre-wrap;"
+					>
+						{#if ($config?.ui?.pending_user_overlay_content ?? '').trim() !== ''}
+							{$config.ui.pending_user_overlay_content}
+						{:else}
+							{$i18n.t('Your account status is currently pending activation.')}{'\n'}{$i18n.t(
+								'To access the WebUI, please reach out to the administrator. Admins can manage user statuses from the Admin Panel.'
+							)}
+						{/if}
+					</div>
+				{/if}
 
 				{#if adminDetails}
 					<div class="mt-4 text-sm font-medium text-center">

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -276,7 +276,7 @@
 		<div
 			class=" text-gray-700 dark:text-gray-100 bg-white dark:bg-gray-900 h-screen max-h-[100dvh] overflow-auto flex flex-row justify-end"
 		>
-			{#if !['user', 'admin'].includes($user?.role)}
+			{#if $user && (!['user', 'admin'].includes($user.role) || $user.is_email_verified === false)}
 				<AccountPending />
 			{:else}
 				{#if localDBChats.length > 0}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -595,7 +595,9 @@
 				} else {
 					// Don't redirect if we're already on the auth page
 					// Needed because we pass in tokens from OAuth logins via URL fragments
-					if ($page.url.pathname !== '/auth') {
+					const publicRoutes = ['/auth', '/verify'];
+
+					if (!publicRoutes.some((route) => $page.url.pathname.startsWith(route))) {
 						await goto(`/auth?redirect=${encodedUrl}`);
 					}
 				}

--- a/src/routes/verify/+page.svelte
+++ b/src/routes/verify/+page.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+	import { onMount, getContext } from 'svelte';
+
+	const i18n = getContext('i18n');
+
+	let message = 'Verifying...';
+	let status = 'loading';
+
+	onMount(async () => {
+		const token = $page.url.searchParams.get('token');
+		const res = await fetch(`${WEBUI_API_BASE_URL}/profiles/verify-email?token=${token}`);
+		if (res.ok) {
+			message = 'Your email has been verified!';
+			status = 'success';
+		} else {
+			const err = await res.json();
+			message = err.detail || 'Invalid or expired verification link.';
+			status = 'error';
+		}
+	});
+</script>
+
+<div class="absolute w-full h-full flex z-50">
+	<div class="absolute rounded-xl w-full h-full backdrop-blur-sm flex justify-center">
+		<div class="m-auto pb-44 flex flex-col justify-center">
+			<div class="max-w-md">
+				<div class="text-center text-2xl font-medium z-50">
+					{message}
+				</div>
+
+				<div class=" mt-4 text-center text-sm w-full">
+					You can now log in to access your account. If your account has already been approved by an
+					administrator, you’ll have full access to the system. If you haven’t been approved yet,
+					please wait for admin approval before logging in.
+					<br class=" " />
+					<br class=" " />
+				</div>
+
+				<div class=" mt-6 mx-auto relative group w-fit">
+					<button
+						class="relative z-20 flex px-5 py-2 rounded-full bg-gray-100 hover:bg-gray-200 transition font-medium text-sm"
+						on:click={() => {
+							location.href = '/';
+						}}
+					>
+						{$i18n.t('Sign in')}
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## Source
https://trello.com/c/0ZEjcrIA/30-ai-sprint-6-openwebui-send-email-after-registrations-to-the-admin
https://trello.com/c/ikcQNMEa/31-ai-sprint-6-openwebui-email-verification

## Descripton
- Send an email to the admin regarding new registrations
- After registration, users must verify their email address.
- Add an is_email_verified field to the UserProfile.
- Send a verification email to the user upon registration.
- If a user attempts to log in without verifying their email, resend the verification email


# Setup instructions
As per https://github.com/developersociety/castopenwebui/pull/3
Make sure you run the server like `LOCAL=1 ./dev.sh` to debug emails in the console

## How to test
1. Visit http://localhost:5173/auth and click **Sign up** enter your details make sure that you enter charity matching email for example `tes@ifcharity.org.uk` and select **If ...** charity and try to submit the form, check the console, and you should see two emails being sent, one for the admin regarding for new reigistrations and another one for verifying the email
2. Check the console, and you should seea  link to verify your email address like http://localhost:8080/verify?token=ImlmYXNAaWZjaGFyaXR5Lm9yZy51ayI.aIJr3A.lRhHtybNBqSHtz3olWH8u9ZAkqI  replace port to 5173 and try to visit and it should verified your email
3. With admin user go to http://localhost:5173/admin/users/overview and check if you can edit the user by letting to change `is_email_verified`